### PR TITLE
Use PLATFORM_HAS_CC2538 as supported Contiki platform

### DIFF
--- a/platform-specific/platform.h
+++ b/platform-specific/platform.h
@@ -48,10 +48,10 @@
 #  include "platform-specific/config-cc2538dk.h"
 #endif /* CONTIKI_TARGET_CC2538DK */
 
-#ifdef CONTIKI_TARGET_FELICIA
+#ifdef PLATFORM_HAS_CC2538
 #define CONTIKI_TARGET_CC2538DK 1
 #  include "platform-specific/config-cc2538dk.h"
-#endif /* CONTIKI_TARGET_FELICIA */
+#endif /* PLATFORM_HAS_CC2538 */
 
 #ifdef CONTIKI_TARGET_WISMOTE
 #  include "platform-specific/config-wismote.h"


### PR DESCRIPTION
Fix compilation error for zoul-sparrow platform. **_(Currently, it only supports felicia platform, compiling tinydtls for zoul-sparrow get linker errors complaining about 'assert' function.)_**

Please merge this PR ASAP.
After this PR is merged, I will submit another PR to Sparrow to update the tinydtls submodule.

Thanks.